### PR TITLE
cleanup additional debug logs

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,7 +2,7 @@ package quickfix
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -32,16 +32,20 @@ type LogFactory interface {
 }
 
 func logWithTracef(format string, a ...interface{}) string {
-	return logWithTrace(fmt.Sprintf(format, a...))
+	msg := fmt.Sprintf(format, a...)
+	return logWithTracePCSkip(msg, 3)
 }
 
 func logWithTrace(msg string) string {
+	return logWithTracePCSkip(msg, 3)
+}
+
+func logWithTracePCSkip(msg string, pcSkip int) string {
 	pc := make([]uintptr, 10) // at least 1 entry needed
-	runtime.Callers(2, pc)
+	runtime.Callers(pcSkip, pc)
 	f := runtime.FuncForPC(pc[0])
 	file, line := f.FileLine(pc[0])
-	dir, _ := os.Getwd()
-	file = strings.ReplaceAll(file, dir, "")
+	file = filepath.Base(file)
 	funcName := strings.ReplaceAll(f.Name(), getModuleName(pc[0]), "")
 	return fmt.Sprintf("%s (%s:%d%s)", msg, file, line, funcName)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,19 @@
+package quickfix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_logWithTrace(t *testing.T) {
+	result := logWithTrace("test_msg")
+	expected := "test_msg (log_test.go:10.Test_logWithTrace)"
+	assert.Equal(t, expected, result)
+}
+
+func Test_logWithTracef(t *testing.T) {
+	result := logWithTracef("test_msg_%s", "formatter")
+	expected := "test_msg_formatter (log_test.go:16.Test_logWithTracef)"
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
- correctly report function caller when using `logWithTracef`
- fix filename log that was printing the gomodule path as well